### PR TITLE
Add Linux installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,28 @@ For contributions, please open up a pull request.
 
 ## Website
 For everything else, please visit the [website](https://hielkeminecraft.github.io/OpenNoteBlockStudio/).
+
+## Linux Installation Guide
+If you want to install Open Note Block Studio on Linux, you have to use WINE. This guide was written using an installation on Ubuntu 20.04 LTS.
+
+1. Install WINE (if you already have WINE installed, you can skip this step):
+```sh
+$ sudo dpkg --add-architecture i386
+$ wget -qO - https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
+$ sudo add-apt-repository ppa:cybermax-dexter/sdl2-backport
+$ sudo apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu $(lsb_release -cs) main"
+$ sudo apt update && sudo apt install --install-recommends winehq-stable
+```
+2. After installing WINE, run `winecfg`, click the "Audio" tab, and set everything to "PulseAudio".
+3. Start the Open Note Block Studio .exe binary with WINE: (Replace `/path/to/your/file` with the directory you downloaded the .exe binary)
+```sh
+$ wine /home/path/to/your/file/Minecraft.Note.Block.Studio.exe
+```
+4. Follow the instructions of the installer.
+5. After installation, navigate to your `.bashrc` file and open it.
+6. Add this line to your `.bashrc` file:
+```sh
+alias wine="PULSE_LATENCY_MSEC=10 wine"
+```
+7. Restart your terminal and open the installed Minecraft Note Block Studio.
+


### PR DESCRIPTION
Added a Linux installation guide for people who want to install Minecraft Note Block Studio on Linux. Feel free to move this installation guide anywhere if you don't want it to be in README.

This installation guide was written with my installation of Open NBS on Ubuntu 20.04 LTS


Importance of this pull request:

Just directly WINEing the .exe file will not work on all distros. PulseAudio will mess up the audio (crackling sounds, delay) on Ubuntu and Debian and other related distros. This PR adds a fix to this to make sure it works flawlessly on these specific distros.